### PR TITLE
Add Rails functionality for "draft" posts

### DIFF
--- a/rails/app/controllers/api/posts_controller.rb
+++ b/rails/app/controllers/api/posts_controller.rb
@@ -2,7 +2,11 @@ class Api::PostsController < ApplicationController
   def index
     # TODO not sure what you need, but you can do something like this to only return specific fields
     # render json: Posts.all.pluck(:title, :post_slug, :excerpt, :published_date)
-    render json: Posts.all
+    if params[:draft]
+      render json: Posts.draft
+    else
+      render json: Posts.all
+    end
   end
 
   def show
@@ -35,11 +39,6 @@ class Api::PostsController < ApplicationController
     else
       render json: post
     end
-  end
-
-  def draft
-    # TODO Still need to wire this up to Ember somehow...
-    render json: Posts.draft
   end
 
 private

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -6,8 +6,6 @@ Backend::Application.routes.draw do
   # root 'welcome#index'
   namespace :api do
     resources :posts
-    # This shows the draft posts
-    get 'drafts', to: 'posts#draft'
   end
 
   devise_for :users, controllers: { sessions: 'sessions' }


### PR DESCRIPTION
I used the `is_published` you already had and just created a default scope. If you don't want a default scope and want to explicitly call for published posts, you can do something like this:

``` ruby
scope :published, -> { where(is_published: true) }
# then to get those records
Posts.published
```

The default scope, however, makes it a bit easier so you don't have to always remember to specify the published posts.

Also, added ability to view draft posts by adding a `draft = true` param, e.g.: `http://localhost:3000/api/posts?draft=true`
