### PR TITLE
Default proxy for your Rails API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Setting up the front end:
 
 ## Running the servers
 In rails/, run `bundle exec rails s`
-In ember/, run `ember server --proxy http://localhost:3000`
+In ember/, run `ember server`

--- a/ember/.ember-cli
+++ b/ember/.ember-cli
@@ -5,5 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
+  "disableAnalytics": false,
+  "proxy": "http://localhost:3000"
 }


### PR DESCRIPTION
Now you don't have to do `ember server --proxy http://localhost:3000`; just do `ember server`! :+1:
